### PR TITLE
Add darkmode colors for the catalog tab

### DIFF
--- a/core/src/main/res/color/palace_tab_button_text.xml
+++ b/core/src/main/res/color/palace_tab_button_text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/PalaceButtonOutlinedDisabledTextColor" android:state_enabled="false" />
-    <item android:color="@color/PalaceTextColor" android:state_checked="true" />
-    <item android:color="@color/PalaceTextColor" />
+    <item android:color="@color/EkirjastoTabButtonDisabledTextColor" android:state_enabled="false" />
+    <item android:color="@color/EkirjastoTabTextColorChecked" android:state_checked="true" />
+    <item android:color="@color/EkirjastoTabTextColor" />
 </selector>

--- a/core/src/main/res/values-night/colors.xml
+++ b/core/src/main/res/values-night/colors.xml
@@ -46,4 +46,11 @@
 
     <!-- Dividers -->
     <color name="PalaceDividerColor">@color/PalaceGrey1</color>
+
+    <!-- TabButtons -->
+    <color name="EkirjastoTabButtonBackgroundColor">@color/EkirjastoBlack</color>
+    <color name="EkirjastoTabButtonDisabledTextColor">@color/EkirjastoGrey</color>
+    <color name="EkirjastoTabTextColorChecked">@color/EkirjastoWhite</color>
+    <color name="EkirjastoTabTextColor">@color/EkirjastoWhite</color>
+
 </resources>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -50,5 +50,8 @@
 
     <!-- TabButtons -->
     <color name="EkirjastoTabButtonBackgroundColor">@color/EkirjastoLightGrey</color>
-    <color name="EkirjastoTabButtonDividerColor">@color/EkirjastoGrey</color>
+    <color name="EkirjastoTabButtonDisabledTextColor">@color/EkirjastoGrey</color>
+    <color name="EkirjastoTabTextColorChecked">@color/EkirjastoBlack</color>
+    <color name="EkirjastoTabTextColor">@color/EkirjastoBlack</color>
+
 </resources>


### PR DESCRIPTION
Added dark mode versions for the tab colors in colors.xml into night/colors.xml, because there was no dark version before. This is the tab with three buttons shown on catalog page. Placed all the colors used in the tabs into the same spot in the files, because before the colors in use were from random spots in colors.xml. Changed the color names to match the use cases. Deleted one unused color.

Ref EKIR-94