### PR TITLE
Add style for settings page

### DIFF
--- a/core/src/main/res/drawable/ekirjasto_arrow_forward.xml
+++ b/core/src/main/res/drawable/ekirjasto_arrow_forward.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp">
+
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M6.23,20.23l1.77,1.77l10,-10l-10,-10l-1.77,1.77l8.23,8.23z"/>
+</vector>

--- a/core/src/main/res/values-night/colors.xml
+++ b/core/src/main/res/values-night/colors.xml
@@ -53,4 +53,9 @@
     <color name="EkirjastoTabTextColorChecked">@color/EkirjastoWhite</color>
     <color name="EkirjastoTabTextColor">@color/EkirjastoWhite</color>
 
+    <!--- Settings -->
+    <color name="EkirjastoSettingsBackground">#000000</color>
+    <color name="EkirjastoSettingsButtonOutline">@color/EkirjastoBlack</color>
+    <color name="EkirjastoSettingsBookmarkBackground">#000000</color>
+
 </resources>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -54,4 +54,9 @@
     <color name="EkirjastoTabTextColorChecked">@color/EkirjastoBlack</color>
     <color name="EkirjastoTabTextColor">@color/EkirjastoBlack</color>
 
+    <!--- Settings -->
+    <color name="EkirjastoSettingsBackground">@color/EkirjastoLightestGrey</color>
+    <color name="EkirjastoSettingsButtonOutline">@color/EkirjastoLightestGrey</color>
+    <color name="EkirjastoSettingsBookmarkBackground">@color/EkirjastoWhite</color>
+
 </resources>

--- a/core/src/main/res/values/ekirjasto_palette.xml
+++ b/core/src/main/res/values/ekirjasto_palette.xml
@@ -8,5 +8,6 @@
     <color name="EkirjastoBlack">#1E1E1E</color>
     <color name="EkirjastoGrey">#9A9A9A</color>
     <color name="EkirjastoLightGrey">#D8D8D8</color>
+    <color name="EkirjastoLightestGrey">#F2F2F2</color>
     <color name="EkirjastoWhite">#FFFFFF</color>
 </resources>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -209,6 +209,29 @@
         -->
     </style>
 
+    <!-- The settings style -->
+    <style name="Palace.Button.Outlined.Settings" parent="Palace.Button.Outlined.Medium">
+        <item name="strokeColor">@color/EkirjastoSettingsButtonOutline</item>
+        <item name="strokeWidth">1dp</item>
+        <item name="shapeAppearance">@style/ShapeAppearance.Material3.Corner.None</item>
+        <item name="android:gravity">left|center_vertical</item>
+        <item name="android:drawableRight">@drawable/ekirjasto_arrow_forward</item>
+        <item name="android:paddingRight">16dp</item>
+        <item name="android:drawableTint">@color/EkirjastoGreen</item>
+        <item name="android:insetBottom">0dp</item>
+        <item name="android:insetTop">0dp</item>
+        <item name="android:fontFamily">@font/asap_regular</item>
+        <item name="android:textSize">14sp</item>
+    </style>
+
+    <style name="Palace.TextViewStyle.Settings" parent="android:Widget.TextView">
+        <item name="android:fontFamily">@font/asap_regular</item>
+        <item name="android:paddingTop">8dp</item>
+        <item name="android:paddingBottom">8dp</item>
+        <item name="android:paddingRight">22dp</item>
+        <item name="android:paddingLeft">22dp</item>
+    </style>
+
     <!-- The bottom navigation view. -->
     <style name="Palace.BottomNavigationView" parent="Widget.Material3.BottomNavigationView">
         <item name="materialThemeOverlay">@style/Palace.BottomNavigationView.Overlay</item>


### PR DESCRIPTION
Added a style for settings page buttons
and settings text views in the styles.xml
file. Added a new color LightestGray into
ekirjasto_palette.xml for the settings
background color. Also added new colors
needed in the settings into colors.xml.
Added a drawable for the button arrow.

To note: Buttons are still the width of the 
screen in any screen size, so the buttons are
very wide on bigger screens.

Ref SIMPLYE-317