### PR TITLE
Fix button styles

### DIFF
--- a/core/src/main/res/values-night/colors.xml
+++ b/core/src/main/res/values-night/colors.xml
@@ -13,7 +13,7 @@
     <color name="PalaceInvertedBackgroundColor">@color/PalaceGrey3</color>
 
     <!-- Contained buttons. -->
-    <color name="PalaceButtonContainedBackgroundColor">@color/PalaceGrey3</color>
+    <color name="PalaceButtonContainedBackgroundColor">@color/EkirjastoLightestGreen</color>
     <color name="PalaceButtonContainedDisabledBackgroundColor">@color/PalaceGrey1</color>
     <color name="PalaceButtonContainedDisabledTextColor">@color/PalaceGrey0</color>
     <color name="PalaceButtonContainedTextColor">@color/PalaceGrey0</color>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -13,8 +13,9 @@
     <color name="PalaceInvertedBackgroundColor">@color/EkirjastoBlack</color>
 
     <!-- Contained buttons. -->
-    <color name="PalaceButtonContainedBackgroundColor">@color/EkirjastoLightGreen</color>
+    <color name="PalaceButtonContainedBackgroundColor">@color/EkirjastoLightestGreen</color>
     <color name="PalaceButtonContainedDisabledBackgroundColor">@color/EkirjastoLightestGreen</color>
+    <color name="PalaceButtonContainedStrokeColor">@color/EkirjastoGreen</color>
     <color name="PalaceButtonContainedDisabledTextColor">@color/EkirjastoGrey</color>
     <color name="PalaceButtonContainedTextColor">@color/EkirjastoBlack</color>
 

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -124,6 +124,8 @@
         <item name="android:backgroundTint">@color/palace_button_contained_color</item>
         <item name="android:textAppearance">@style/Palace.ButtonContained.Text</item>
         <item name="android:textColor">@color/palace_button_contained_text_color</item>
+        <item name="strokeColor">@color/PalaceButtonContainedStrokeColor</item>
+        <item name="strokeWidth">1dp</item>
         <item name="android:drawableTintMode">multiply</item>
         <item name="android:drawableTint">@color/palace_button_contained_text_color</item>
         <item name="android:scrollbars">none</item>
@@ -174,8 +176,9 @@
         <item name="android:drawableTintMode">multiply</item>
         <item name="android:drawableTint">@color/palace_button_outlined_text_color</item>
         <item name="android:scrollbars">none</item>
-        <item name="strokeColor">@color/PalacePrimaryForegroundColor</item>
+        <item name="strokeColor">@color/PalaceButtonOutlinedOutlineColor</item>
         <item name="rippleColor">#cccccc</item>
+        <item name="colorPrimary">@color/EkirjastoWhite</item>
         <item name="shapeAppearance">@style/ShapeAppearance.Material3.Corner.Small</item>
     </style>
 


### PR DESCRIPTION
Added a EkirjastoGreen stroke to the
contained buttons and adjusted the button
color to lightest green. In outlined buttons
added the correct outline color so it's green
for both dark and light mode. Also added the
colorPrimary = EkirjastoWhite for the outline
buttons. Without that there was some light
green tint in the secondary buttons.

Ref SIMPLYE-297