### PR TITLE
Remove the ekirjasto-android-platform submodule from ekirjasto-android-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "org.thepalaceproject.android.platform"]
-	path = org.thepalaceproject.android.platform
-	url = https://github.com/NatLibFi/ekirjasto-android-platform
-	branch = ekirjasto
 [submodule ".ci"]
 	path = .ci
 	url = https://www.github.com/ThePalaceProject/android-ci


### PR DESCRIPTION
The ekirjasto-android-platform repo is a submodule in both ekirjasto-android-core and ekirjasto-android-theme, so that both can share the same dependencies (most importantly the same versions).

Unlike with the upstream repo (ThePalaceProject/android-theme), there's very little chance that ekirjasto-android-theme would ever be used as a standalone component outside of ekirjasto-android-core, so it can just share the same *directory* containing the platform dependencies instead of the same repo. In other words, ekirjasto-android-theme can access ekirjasto-android-platform through the app's root project, since it's never built as a standalone component.

This will make it much easier to update dependencies, which currently takes 3 PRs, one in each repository (this would cut that down to 2).

We could merge both submodules (theme and platform) straight into the ekirjasto-android-core repository and delete the repositories for them, but that would make it more difficult to take in upstream changes if needed. So, let's keep them as separate repositories.