### PR TITLE
Search for build_libraries.toml from multiple paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ ktlint.jar
 # Auto-generated, ignore
 configurations.txt
 
+# Ignore old submodule
+org.thepalaceproject.android.platform/
+ekirjasto-android-platform/
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,7 +9,19 @@ pluginManagement {
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
-            from(files("$rootDir/org.thepalaceproject.android.platform/build_libraries.toml"))
+            val pathsToTry = listOf(
+                "$rootDir/../org.thepalaceproject.android.platform/build_libraries.toml",
+                "$rootDir/../ekirjasto-android-platform/build_libraries.toml",
+                "$rootDir/org.thepalaceproject.android.platform/build_libraries.toml",
+                "$rootDir/ekirjasto-android-platform/build_libraries.toml",
+            )
+            for (pathToTry in pathsToTry) {
+                if (file(pathToTry).exists()) {
+                    println("Using build_libraries.toml from path: $pathToTry")
+                    from(files(pathToTry))
+                    break
+                }
+            }
         }
     }
 


### PR DESCRIPTION
The ekirjasto-android-platform submodule was removed from this repository, in order to make it easier to manage dependencies in ekirjasto-android-core. This broke building this repository as a standalone module.

This commit adds code to search for build_libraries.toml from multiple different paths, so that this project can be built as a standalone module when it has been cloned as a part of ekirjasto-android-core, or optionally by manually cloning the ekirjasto-android-platform repo.