### PR TITLE
Make bottom tab text slightly smaller (13 sp -> 12 sp)

### DIFF
--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -260,7 +260,12 @@
         <item name="labelVisibilityMode">labeled</item>
         <item name="itemActiveIndicatorStyle">@style/Palace.BottomNavigationView.Indicator</item>
         <item name="itemTextColor">@color/PalaceButtonTextTextColor</item>
+        <item name="itemTextAppearanceInactive">@style/Palace.BottomNavigationView.TextInactive</item>
         <item name="itemTextAppearanceActive">@style/Palace.BottomNavigationView.TextActive</item>
+    </style>
+
+    <style name="Palace.BottomNavigationView.TextInactive" parent="">
+        <item name="android:textSize">12sp</item>
     </style>
 
     <style name="Palace.BottomNavigationView.TextActive" parent="">


### PR DESCRIPTION
This makes slightly too long tab titles like "Browse books" and "Reservationer" fit better for common resolutions, without making the tabs too much harder to read.