### PR TITLE
Ekir 185 settings page style changes for language option

### DIFF
--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -257,7 +257,7 @@
         <item name="android:paddingLeft">22dp</item>
     </style>
 
-    <style name="Palace.TextViewStyle.Settings.Info" parent="Palace.TextViewStyle.Settings">
+    <style name="Palace.TextViewStyle.Settings.Dark" parent="Palace.TextViewStyle.Settings">
         <item name="android:textColor">@color/palace_button_text_color</item>
         <item name="android:textSize">14sp</item>
     </style>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -235,15 +235,19 @@
         <item name="strokeColor">@color/EkirjastoSettingsButtonOutline</item>
         <item name="strokeWidth">1dp</item>
         <item name="shapeAppearance">@style/ShapeAppearance.Material3.Corner.None</item>
-        <item name="android:gravity">left|center_vertical</item>
-        <item name="android:drawableRight">@drawable/ekirjasto_arrow_forward</item>
-        <item name="android:paddingRight">16dp</item>
-        <item name="android:drawableTint">@color/EkirjastoGreen</item>
         <item name="android:insetBottom">0dp</item>
         <item name="android:insetTop">0dp</item>
         <item name="android:fontFamily">@font/asap_regular</item>
         <item name="android:textSize">14sp</item>
     </style>
+
+    <style name="Palace.Button.Outlined.Settings.Arrowed" parent="Palace.Button.Outlined.Settings">
+        <item name="android:gravity">left|center_vertical</item>
+        <item name="android:drawableRight">@drawable/ekirjasto_arrow_forward</item>
+        <item name="android:paddingRight">16dp</item>
+        <item name="android:drawableTint">@color/EkirjastoGreen</item>
+    </style>
+
 
     <style name="Palace.TextViewStyle.Settings" parent="android:Widget.TextView">
         <item name="android:fontFamily">@font/asap_regular</item>
@@ -252,6 +256,12 @@
         <item name="android:paddingRight">22dp</item>
         <item name="android:paddingLeft">22dp</item>
     </style>
+
+    <style name="Palace.TextViewStyle.Settings.Info" parent="Palace.TextViewStyle.Settings">
+        <item name="android:textColor">@color/palace_button_text_color</item>
+        <item name="android:textSize">14sp</item>
+    </style>
+
 
     <!-- The bottom navigation view. -->
     <style name="Palace.BottomNavigationView" parent="Widget.Material3.BottomNavigationView">


### PR DESCRIPTION
Added a new base button for settings page, and added the old button style as arrowed. The base buttons are used for language buttons, where text is centered, and there is no arrow. Also added a new text style, that only differs so that button color is palacegray0, when the other texts are in ekirjastoBlack.