### PR TITLE
Ensure logo always shows when needed

### DIFF
--- a/core/src/main/kotlin/PalaceToolbar.kt
+++ b/core/src/main/kotlin/PalaceToolbar.kt
@@ -100,7 +100,12 @@ class PalaceToolbar(
       this.iconView.contentDescription = context.getString(R.string.contentDescriptionBack)
     } else {
       this.iconKind = IconKind.ICON_IS_LOGO
-      this.setLogo(this.iconLogoLast)
+      //In case we reconfigure the toolbar so that iconLogoLast is not set, set the ekirjasto logo
+      if (this.iconLogoLast == null) {
+        this.setLogo(R.drawable.ekirjasto_logo_smaller)
+      } else {
+        this.setLogo(this.iconLogoLast)
+      }
       this.iconView.setPadding(0,0,0,0)
       this.iconView.contentDescription = context.getString(R.string.contentDescriptionLogo)
     }


### PR DESCRIPTION
IconLogoLast is forgotten when MainApplication recreate is run, so in order for the logo to show on account page when we return after changing textsize, we set the logo as the
ekirjasto logo when toolbar recinfigure call is done, if there is no iconLogoLast. This is fine as the logo is always the same.

Ref EKIR-297