### PR TITLE
Decrease button padding and add rolling title

### DIFF
--- a/core/src/main/kotlin/PalaceToolbar.kt
+++ b/core/src/main/kotlin/PalaceToolbar.kt
@@ -2,6 +2,7 @@ package org.thepalaceproject.theme.core
 
 import android.content.Context
 import android.graphics.drawable.Drawable
+import android.text.TextUtils
 import android.util.AttributeSet
 import android.view.Gravity
 import android.widget.ImageView
@@ -127,6 +128,12 @@ class PalaceToolbar(
 
   override fun setTitle(title: CharSequence) {
     this.titleView.text = title
+    //If the text is too long for its space, make it scrolling
+    this.titleView.ellipsize = TextUtils.TruncateAt.MARQUEE
+    //Set it as selected, so the text actually scrolls
+    this.titleView.setSelected(true)
+    //Ensure the text remains on one row
+    this.titleView.setSingleLine(true)
   }
 
   private fun getSearchViewFromToolbar(): SearchView? {

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -129,6 +129,8 @@
         <item name="android:drawableTintMode">multiply</item>
         <item name="android:drawableTint">@color/palace_button_contained_text_color</item>
         <item name="android:scrollbars">none</item>
+        <item name="android:paddingLeft">10dp</item>
+        <item name="android:paddingRight">10dp</item>
         <item name="shapeAppearance">@style/ShapeAppearance.Material3.Corner.Small</item>
     </style>
 
@@ -179,6 +181,8 @@
         <item name="strokeColor">@color/PalaceButtonOutlinedOutlineColor</item>
         <item name="rippleColor">#cccccc</item>
         <item name="colorPrimary">@color/EkirjastoWhite</item>
+        <item name="android:paddingLeft">10dp</item>
+        <item name="android:paddingRight">10dp</item>
         <item name="shapeAppearance">@style/ShapeAppearance.Material3.Corner.Small</item>
     </style>
 


### PR DESCRIPTION
Decrease the required padding for both primary
and secondary buttons, so more text fits into them without the need to be ellipsized.

Also makes the text on toolbar to be rolling, so that whole text in it is readable when the text is long and font is big.

REF: EKIR-375, EKIR-363, EKIR-377