### PR TITLE
Add an invisible ekirjasto logo to boot

### DIFF
--- a/core/src/main/res/drawable/ekirjasto_logo_invisible.xml
+++ b/core/src/main/res/drawable/ekirjasto_logo_invisible.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <group android:scaleX="0.079793334"
+        android:scaleY="0.079793334"
+        android:translateX="17.526546"
+        android:translateY="11.136963">
+    <path android:fillColor="@color/PalaceScreenBackgroundColor" android:pathData="M708.2,275.9c0,-46 -37.3,-83.4 -83.3,-83.4c0,0 -312.2,0 -325.5,0c-53,-0.1 -76.8,-31.1 -88.1,-52.6h-2.9l0.1,138.4c1.3,44.9 38,80.9 83.1,80.9h333.3C670.9,359.3 708.2,322 708.2,275.9"/>
+    <path android:fillColor="@color/PalaceScreenBackgroundColor" android:pathData="M791.7,776.6c0,-46 -37.3,-83.4 -83.3,-83.4c0,0 -395.7,0 -409,0c-53,0 -76.8,-31.1 -88.1,-52.5h-2.9l0.1,138.4c1.3,44.9 38,80.9 83.1,80.9h416.8C754.4,859.9 791.7,822.6 791.7,776.6"/>
+    <path android:fillColor="@color/PalaceScreenBackgroundColor" android:pathData="M624.9,526.1c0,-46 -37.3,-83.4 -83.3,-83.4c0,0 -229,0 -242.3,0c-53,0 -76.8,-31.1 -88.1,-52.5h-2.9l0.1,138.4c1.3,44.9 38,80.9 83.1,80.9h250.1C587.6,609.5 624.9,572.1 624.9,526.1"/>
+    </group>
+</vector>

--- a/core/src/main/res/values-v31/themes.xml
+++ b/core/src/main/res/values-v31/themes.xml
@@ -49,7 +49,7 @@
         <item name="textInputStyle">@style/Palace.TextInputLayout</item>
         <item name="toolbarStyle">@style/Palace.Toolbar</item>
 
-        <item name="android:windowSplashScreenAnimatedIcon">@drawable/palace_splash_animated</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@drawable/ekirjasto_logo_invisible</item>
     </style>
 
     <style name="PalaceTheme.WithActionBar" parent="Theme.Material3.DayNight">
@@ -89,6 +89,6 @@
         <item name="textInputStyle">@style/Palace.TextInputLayout</item>
         <item name="toolbarStyle">@style/Palace.Toolbar</item>
 
-        <item name="android:windowSplashScreenAnimatedIcon">@drawable/palace_splash_animated</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@drawable/ekirjasto_logo_invisible</item>
     </style>
 </resources>


### PR DESCRIPTION
Added a ekirjasto logo that matches the background color of the app, so it appears invisible. Replace the palace logo shown on launch with the invisible ekirjasto logo.

If we wish to show the logo, the colors can be changed, or if the ref is deleted from themes, the icon set in ekirjasto-android-core is shown.

Did not adjust how long the splash is shown.

Ref: EKIRJASTO-90