### PR TITLE
EKIRJASTO-86 More fixes

### DIFF
--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -327,8 +327,9 @@
         <item name="shapeAppearance">@style/ShapeAppearance.Material3.SmallComponent</item>
     </style>
 
-    <style name="Palace.MaterialAlertDialog.Button" parent="Widget.Material3.Button.TextButton.Dialog">
+     <style name="Palace.MaterialAlertDialog.Button" parent="Widget.Material3.Button">Add commentMore actions
         <item name="android:textColor">@color/PalaceTextColor</item>
+        <item name="strokeColor">@color/EkirjastoGreen</item>
     </style>
 
     <style name="Ekirjasto.MaterialAlertDialog.Text" parent="MaterialAlertDialog.Material3.Body.Text">

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -327,7 +327,7 @@
         <item name="shapeAppearance">@style/ShapeAppearance.Material3.SmallComponent</item>
     </style>
 
-     <style name="Palace.MaterialAlertDialog.Button" parent="Widget.Material3.Button">Add commentMore actions
+     <style name="Palace.MaterialAlertDialog.Button" parent="Widget.Material3.Button">
         <item name="android:textColor">@color/PalaceTextColor</item>
         <item name="strokeColor">@color/EkirjastoGreen</item>
     </style>


### PR DESCRIPTION
Change alert button colors to more accessible ones. These are used for loan revoke and logout confirmations, as well as some other info popups.