### PR TITLE
Feature/readium 3x migration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,8 @@
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.gradle.LibraryExtension
-import org.jetbrains.kotlin.de.undercouch.gradle.tasks.download.Download
-import org.jetbrains.kotlin.de.undercouch.gradle.tasks.download.Verify
+import de.undercouch.gradle.tasks.download.Download
+import de.undercouch.gradle.tasks.download.Verify
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 
@@ -277,7 +278,9 @@ allprojects {
              */
 
             tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-                kotlinOptions.jvmTarget = jdkBytecodeTarget.toString()
+                compilerOptions {
+                    jvmTarget.set(JvmTarget.fromTarget(jdkBytecodeTarget.toString()))
+                }
             }
             java.sourceCompatibility = JavaVersion.toVersion(jdkBytecodeTarget)
             java.targetCompatibility = JavaVersion.toVersion(jdkBytecodeTarget)
@@ -332,7 +335,9 @@ allprojects {
              */
 
             tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-                kotlinOptions.jvmTarget = jdkBytecodeTarget.toString()
+                compilerOptions {
+                    jvmTarget.set(JvmTarget.fromTarget(jdkBytecodeTarget.toString()))
+                }
             }
             java.sourceCompatibility = JavaVersion.toVersion(jdkBytecodeTarget)
             java.targetCompatibility = JavaVersion.toVersion(jdkBytecodeTarget)
@@ -388,7 +393,9 @@ allprojects {
              */
 
             tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-                kotlinOptions.jvmTarget = jdkBytecodeTarget.toString()
+                compilerOptions {
+                    jvmTarget.set(JvmTarget.fromTarget(jdkBytecodeTarget.toString()))
+                }
             }
             java.sourceCompatibility = JavaVersion.toVersion(jdkBytecodeTarget)
             java.targetCompatibility = JavaVersion.toVersion(jdkBytecodeTarget)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.de.undercouch.gradle.tasks.download.Verify
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 
-val gradleVersionRequired = "8.7"
+val gradleVersionRequired = "8.14.3"
 val gradleVersionReceived = gradle.gradleVersion
 
 if (gradleVersionRequired != gradleVersionReceived) {


### PR DESCRIPTION
**What's this do?**
Compatibility changes for the core Readium 3.x migration:
 - Bump the Gradle version check 8.7 → 8.14.3
 - Kotlin 2.x compatibility fixes in the root build.gradle.kts

**Why are we doing this? (w/ JIRA link if applicable)**
Theme module must build under the migration's toolchain (Kotlin 2.2 / Gradle 8.14.3).

**How should this be tested? / Do these changes have associated tests?**
Builds as part of the core app; verified via the core build + device QA.

**Dependencies for merging? Releasing to production?**
Paired with NatLibFi/ekirjasto-android-core#263. ⚠️ Merge with a MERGE COMMIT, not squash —the core repo pins this repo's exact commit SHA as a submodule pointer. Merge before the core PR.

**Have you updated the changelog?**
N/A

**Has the application documentation been updated for these changes?**
Covered by the core migration documentation (delivered separately).

**Did someone actually run this code to verify it works?**
Yes — via the core app build + device QA.

**Does this require updates to old Transifex strings? Have the translators been informed?**
No — no string changes.

**AI was used during the process**
AI was used to apply these Kotlin 2.x / Gradle compatibility changes as part of the Readium 3.x migration, under developer review.

- [x] AI was used during the process and I have described above how.